### PR TITLE
Remove mutex from Connection function

### DIFF
--- a/connection_producer.go
+++ b/connection_producer.go
@@ -72,8 +72,6 @@ func (c *mongoDBAtlasConnectionProducer) Close() error {
 }
 
 func (c *mongoDBAtlasConnectionProducer) Connection(_ context.Context) (interface{}, error) {
-	c.Lock()
-	defer c.Unlock()
 
 	if !c.Initialized {
 		return nil, connutil.ErrNotInitialized


### PR DESCRIPTION
For some reason, Connection cannot lock the mutex and hangs the
plugin, removing the lock makes this work again.